### PR TITLE
fix: codeowner order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 *    @abcxyz/breakglass
 
 # spc-wg owns all files
-*    @abcxyz/spc-wg
+*    @abcxyz/compliance-tooling


### PR DESCRIPTION
We want both codeowners? I only see Seth is codeowner in the pending PRs. 
Codeowners order (line order) is important, the later will take precedence. see [link](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)