### PR TITLE
refactor: refactore messanger interface

### DIFF
--- a/pkg/cli/mapping_server.go
+++ b/pkg/cli/mapping_server.go
@@ -117,12 +117,6 @@ func (c *MappingServerCommand) RunUnstarted(ctx context.Context, args []string) 
 		return nil, nil, closer, fmt.Errorf("server.NewHandler: %w", err)
 	}
 
-	closer = func() {
-		if err := handler.Cleanup(); err != nil {
-			logger.Errorw("failed to close clean up handler", "error", err)
-		}
-	}
-
 	srv, err := serving.New(c.cfg.Port)
 	if err != nil {
 		return nil, nil, closer, fmt.Errorf("failed to create serving infrastructure: %w", err)

--- a/pkg/cli/policy_server.go
+++ b/pkg/cli/policy_server.go
@@ -98,12 +98,6 @@ func (c *PolicyServerCommand) RunUnstarted(ctx context.Context, args []string) (
 		return nil, nil, closer, fmt.Errorf("server.NewHandler: %w", err)
 	}
 
-	closer = func() {
-		if err := handler.Cleanup(); err != nil {
-			logger.Errorw("failed to close clean up handler", "error", err)
-		}
-	}
-
 	srv, err := serving.New(c.cfg.Port)
 	if err != nil {
 		return nil, nil, closer, fmt.Errorf("failed to create serving infrastructure: %w", err)

--- a/pkg/mapping/processors/assetinventory.go
+++ b/pkg/mapping/processors/assetinventory.go
@@ -49,14 +49,6 @@ type AssetInventoryProcessor struct {
 // Option is the option to set up a AssetInventoryProcessor.
 type Option func(p *AssetInventoryProcessor) (*AssetInventoryProcessor, error)
 
-// WithClient provides a asset client to the processor.
-func WithClient(client *asset.Client) Option {
-	return func(p *AssetInventoryProcessor) (*AssetInventoryProcessor, error) {
-		p.client = client
-		return p, nil
-	}
-}
-
 // NewAssetInventoryProcessor creates a new AssetInventoryProcessor with the given options.
 // Need defaultResourceScope because resources such as GCS bucket won't include Project info in its resource name.
 // See details: https://cloud.google.com/asset-inventory/docs/resource-name-format.

--- a/pkg/mapping/processors/assetinventory.go
+++ b/pkg/mapping/processors/assetinventory.go
@@ -60,7 +60,7 @@ func WithClient(client *asset.Client) Option {
 // NewAssetInventoryProcessor creates a new AssetInventoryProcessor with the given options.
 // Need defaultResourceScope because resources such as GCS bucket won't include Project info in its resource name.
 // See details: https://cloud.google.com/asset-inventory/docs/resource-name-format.
-func NewAssetInventoryProcessor(ctx context.Context, defaultResourceScope string, opts ...Option) (*AssetInventoryProcessor, error) {
+func NewAssetInventoryProcessor(ctx context.Context, defaultResourceScope string, client *asset.Client, opts ...Option) (*AssetInventoryProcessor, error) {
 	p := &AssetInventoryProcessor{defaultResourceScope: defaultResourceScope}
 	for _, opt := range opts {
 		var err error
@@ -70,13 +70,7 @@ func NewAssetInventoryProcessor(ctx context.Context, defaultResourceScope string
 		}
 	}
 
-	if p.client == nil {
-		client, err := asset.NewClient(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create the Asset Inventory client: %w", err)
-		}
-		p.client = client
-	}
+	p.client = client
 	return p, nil
 }
 

--- a/pkg/mapping/processors/assetinventory.go
+++ b/pkg/mapping/processors/assetinventory.go
@@ -60,7 +60,7 @@ func WithClient(client *asset.Client) Option {
 // NewAssetInventoryProcessor creates a new AssetInventoryProcessor with the given options.
 // Need defaultResourceScope because resources such as GCS bucket won't include Project info in its resource name.
 // See details: https://cloud.google.com/asset-inventory/docs/resource-name-format.
-func NewAssetInventoryProcessor(ctx context.Context, defaultResourceScope string, client *asset.Client, opts ...Option) (*AssetInventoryProcessor, error) {
+func NewAssetInventoryProcessor(ctx context.Context, client *asset.Client, defaultResourceScope string, opts ...Option) (*AssetInventoryProcessor, error) {
 	p := &AssetInventoryProcessor{defaultResourceScope: defaultResourceScope}
 	for _, opt := range opts {
 		var err error
@@ -226,14 +226,6 @@ func (p *AssetInventoryProcessor) getSingleResource(ctx context.Context, req *as
 		return nil, fmt.Errorf("%d matched resources found, expected %d matched resource", got, want)
 	}
 	return resources[0], nil
-}
-
-// Stop stops the processor.
-func (p *AssetInventoryProcessor) Stop() error {
-	if err := p.client.Close(); err != nil {
-		return fmt.Errorf("failed to stop Asset Inventory Processor: %w", err)
-	}
-	return nil
 }
 
 // mergeAnnotations merges two annotations represented by structpb.Struct,

--- a/pkg/mapping/processors/assetinventory_test.go
+++ b/pkg/mapping/processors/assetinventory_test.go
@@ -301,7 +301,7 @@ func TestProcessor_UpdatedProcess(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating client for fake at %q: %v", addr, err)
 			}
-			p, err := NewAssetInventoryProcessor(ctx, "projects/fake-project", fakeAssetClient)
+			p, err := NewAssetInventoryProcessor(ctx, fakeAssetClient, "projects/fake-project")
 			if err != nil {
 				t.Fatalf("failed to create AssetInventoryProcessor: %v", err)
 			}

--- a/pkg/mapping/processors/assetinventory_test.go
+++ b/pkg/mapping/processors/assetinventory_test.go
@@ -301,7 +301,7 @@ func TestProcessor_UpdatedProcess(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating client for fake at %q: %v", addr, err)
 			}
-			p, err := NewAssetInventoryProcessor(ctx, "projects/fake-project", WithClient(fakeAssetClient))
+			p, err := NewAssetInventoryProcessor(ctx, "projects/fake-project", fakeAssetClient)
 			if err != nil {
 				t.Fatalf("failed to create AssetInventoryProcessor: %v", err)
 			}

--- a/pkg/server/event_handler.go
+++ b/pkg/server/event_handler.go
@@ -278,9 +278,6 @@ func (h *EventHandler[T, P]) Handle(ctx context.Context, m pubsub.Message) error
 
 	if processErr != nil {
 		logger.Errorw(processErr.Error(), "bucketId", m.Attributes["bucketId"], "objectId", m.Attributes["objectId"])
-		// TODO(#110): Need to add a LimitReader to read from processErr
-		// before adding it to attr and published by pubsub.
-		// https://cloud.google.com/pubsub/quotas#resource_limits.
 		if err := h.failureMessenger.Send(ctx, eventBytes, attr); err != nil {
 			return fmt.Errorf("failed to send failure event downstream: %w", err)
 		}

--- a/pkg/server/pubsub.go
+++ b/pkg/server/pubsub.go
@@ -23,13 +23,12 @@ import (
 
 // PubSubMessenger implements the Messenger interface for Google Cloud PubSub.
 type PubSubMessenger struct {
-	client *pubsub.Client
-	topic  *pubsub.Topic
+	topic *pubsub.Topic
 }
 
 // NewPubSubMessenger creates a new instance of the PubSubMessenger.
-func NewPubSubMessenger(client *pubsub.Client, topic *pubsub.Topic) *PubSubMessenger {
-	return &PubSubMessenger{client: client, topic: topic}
+func NewPubSubMessenger(topic *pubsub.Topic) *PubSubMessenger {
+	return &PubSubMessenger{topic: topic}
 }
 
 // Send sends a pmap event to a Google Cloud PubSub topic.

--- a/pkg/server/pubsub.go
+++ b/pkg/server/pubsub.go
@@ -41,12 +41,6 @@ func NewPubSubMessenger(ctx context.Context, projectID, topicID string, opts ...
 }
 
 // Send sends a pmap event to a Google Cloud PubSub topic.
-// (ctx, bytes)
-
-//	strcut {
-//		PmapEvent
-//		error
-//	}
 func (p *PubSubMessenger) Send(ctx context.Context, data []byte, attr map[string]string) error {
 	result := p.topic.Publish(ctx, &pubsub.Message{
 		Data:       data,

--- a/pkg/server/pubsub.go
+++ b/pkg/server/pubsub.go
@@ -33,6 +33,9 @@ func NewPubSubMessenger(topic *pubsub.Topic) *PubSubMessenger {
 
 // Send sends a pmap event to a Google Cloud PubSub topic.
 func (p *PubSubMessenger) Send(ctx context.Context, data []byte, attr map[string]string) error {
+	// TODO(#110): Need to add a LimitReader to read from processErr
+	// before adding it to attr and published by pubsub.
+	// https://cloud.google.com/pubsub/quotas#resource_limits.
 	result := p.topic.Publish(ctx, &pubsub.Message{
 		Data:       data,
 		Attributes: attr,

--- a/pkg/server/pubsub.go
+++ b/pkg/server/pubsub.go
@@ -19,9 +19,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/abcxyz/pmap/apis/v1alpha1"
 	"google.golang.org/api/option"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // PubSubMessenger implements the Messenger interface for Google Cloud PubSub.
@@ -43,14 +41,16 @@ func NewPubSubMessenger(ctx context.Context, projectID, topicID string, opts ...
 }
 
 // Send sends a pmap event to a Google Cloud PubSub topic.
-func (p *PubSubMessenger) Send(ctx context.Context, event *v1alpha1.PmapEvent) error {
-	eventBytes, err := protojson.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("failed to marshal event json: %w", err)
-	}
+// (ctx, bytes)
 
+//	strcut {
+//		PmapEvent
+//		error
+//	}
+func (p *PubSubMessenger) Send(ctx context.Context, data []byte, attr map[string]string) error {
 	result := p.topic.Publish(ctx, &pubsub.Message{
-		Data: eventBytes,
+		Data:       data,
+		Attributes: attr,
 	})
 
 	if _, err := result.Get(ctx); err != nil {

--- a/pkg/server/pubsub.go
+++ b/pkg/server/pubsub.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
-	"google.golang.org/api/option"
 )
 
 // PubSubMessenger implements the Messenger interface for Google Cloud PubSub.
@@ -29,15 +28,8 @@ type PubSubMessenger struct {
 }
 
 // NewPubSubMessenger creates a new instance of the PubSubMessenger.
-func NewPubSubMessenger(ctx context.Context, projectID, topicID string, opts ...option.ClientOption) (*PubSubMessenger, error) {
-	client, err := pubsub.NewClient(ctx, projectID, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create new pubsub client: %w", err)
-	}
-
-	topic := client.Topic(topicID)
-
-	return &PubSubMessenger{client: client, topic: topic}, nil
+func NewPubSubMessenger(client *pubsub.Client, topic *pubsub.Topic) *PubSubMessenger {
+	return &PubSubMessenger{client: client, topic: topic}
 }
 
 // Send sends a pmap event to a Google Cloud PubSub topic.
@@ -49,15 +41,6 @@ func (p *PubSubMessenger) Send(ctx context.Context, data []byte, attr map[string
 
 	if _, err := result.Get(ctx); err != nil {
 		return fmt.Errorf("pubsub: failed to get result returned from publish : %w", err)
-	}
-	return nil
-}
-
-// Cleanup handles the graceful shutdown of the PubSub client.
-func (p *PubSubMessenger) Cleanup() error {
-	p.topic.Stop()
-	if err := p.client.Close(); err != nil {
-		return fmt.Errorf("failed to close PubSub client: %w", err)
 	}
 	return nil
 }

--- a/pkg/server/pubsub_test.go
+++ b/pkg/server/pubsub_test.go
@@ -72,8 +72,11 @@ func TestPubSubMessenger_Send(t *testing.T) {
 			if _, err := msger.client.CreateTopic(ctx, serverTopicID); err != nil {
 				t.Fatalf("failed to create test PubSub topic: %v", err)
 			}
-
-			gotErr := msger.Send(ctx, tc.event)
+			eventBytes, err := parsePmapEvent(tc.event)
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+			gotErr := msger.Send(ctx, eventBytes, map[string]string{})
 			if diff := testutil.DiffErrString(gotErr, tc.wantErrSubstr); diff != "" {
 				t.Errorf("Process(%+v) got unexpected error substring: %v", tc.name, diff)
 			}

--- a/pkg/server/pubsub_test.go
+++ b/pkg/server/pubsub_test.go
@@ -110,7 +110,7 @@ func testCreatePubsubTopic(ctx context.Context, t *testing.T, projectID, topicID
 
 	client, err := pubsub.NewClient(ctx, projectID, opts...)
 	if err != nil {
-		t.Fatalf("failed to create new pubsub client: %v", err)
+		t.Fatalf("failed to create pubsub client: %v", err)
 	}
 	if _, err := client.CreateTopic(ctx, serverTopicID); err != nil {
 		t.Fatalf("failed to create test PubSub topic: %v", err)
@@ -120,7 +120,7 @@ func testCreatePubsubTopic(ctx context.Context, t *testing.T, projectID, topicID
 	t.Cleanup(func() {
 		topic.Stop()
 		if err := client.Close(); err != nil {
-			t.Fatalf("failed to close pubsub client: %v", err)
+			t.Logf("failed to close pubsub client: %v", err)
 		}
 	})
 


### PR DESCRIPTION
Refactor the code as a prerequisite for [PR#114](https://github.com/abcxyz/pmap/pull/114), as discussed here: https://github.com/abcxyz/pmap/pull/114#issuecomment-1581375884.

Refactor the Messenger's Send() interface to accept data as byte and attributes as map, as they are needed for publishing the message.

Also removed Cleanup() from Messenger's interface, and move cleanup logic to be handled outside of handler.

fix: #96.