### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'main'
   workflow_dispatch:
+  workflow_call:
 
 env:
   WIF_PROVIDER: 'projects/921163060412/locations/global/workloadIdentityPools/github-pool-3b39/providers/github-provider'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: 'release'
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  # .goreleaser.docker.yaml reads DOCKER_REPO
+  DOCKER_REPO: 'us-docker.pkg.dev/abcxyz-artifacts/docker-images/pmap'
+  WIF_PROVIDER: 'projects/921163060412/locations/global/workloadIdentityPools/github-pool-3b39/providers/github-provider'
+  WIF_SERVICE_ACCOUNT: 'pmap-3b39-ci-sa@pmap-ci.iam.gserviceaccount.com'
+  DEV_PROJECT_ID: 'pmap-dev'
+  DEV_REGION: 'us-central1'
+
+# Don't cancel in progress since we don't want to have half-baked release.
+concurrency: '${{ github.workflow }}-${{ github.head_ref || github.ref }}-release'
+
+jobs:
+  ci:
+    uses: 'abcxyz/pmap/.github/workflows/ci.yml@main' # ratchet:exclude
+
+  image-release:
+    # Run CI before the release
+    needs: ['ci']
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: 'docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18' # ratchet:docker/setup-qemu-action@v2
+      - uses: 'actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: 'actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f' # ratchet:actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          token_format: 'access_token'
+      - name: 'Authenticate to Artifact Registry'
+        uses: 'docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a' # ratchet:docker/login-action@v2
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: 'us-central1-docker.pkg.dev'
+      - uses: 'goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757' # ratchet:goreleaser/goreleaser-action@v3
+        with:
+          version: 'v1.16.1' # Manually pinned
+          args: 'release -f .goreleaser.docker.yaml --clean'
+
+  github-release:
+    needs: ['image-release']
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'write'
+      packages: 'write'
+    steps:
+      - uses: 'actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: 'actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f' # ratchet:actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - uses: 'goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757' # ratchet:goreleaser/goreleaser-action@v3
+        with:
+          version: 'v1.16.1' # Manually pinned
+          args: 'release --clean'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+  deploy-dev-services:
+    needs: ['image-release', 'github-release']
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    strategy:
+      matrix:
+        service_name: ['mapping', 'policy']
+    steps:
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+
+      - name: 'Deploy Cloud Run services'
+        run: |-
+          # Image tags are without 'v' prefix.
+          DOCKER_TAG="${{ github.ref_name }}"
+          DOCKER_TAG="${DOCKER_TAG#v}"
+
+          gcloud run services update ${{ matrix.service_name }} \
+            --project="${{ env.DEV_PROJECT_ID }}" \
+            --region="${{ env.DEV_REGION }}" \
+            --image="${{ env.DOCKER_REPO }}/pmap:${DOCKER_TAG}-amd64"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,70 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env:
+  # Global env vars for Go build.
+  - 'CGO_ENABLED=0'
+  - 'GO111MODULE=on'
+  - 'GOPROXY=https://proxy.golang.org,direct'
+
+before:
+  hooks:
+    - 'go mod tidy'
+
+# Duplicate the builds to .goreleaser.docker.yaml
+builds:
+  -
+    id: 'pamp'
+    main: './cmd/pmap'
+    binary: 'pmap'
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - '-a'
+      - '-trimpath'
+    ldflags:
+      - '-s'
+      - '-w'
+      - '-X={{ .ModulePath }}/internal/version.Name=pmap'
+      - '-X={{ .ModulePath }}/internal/version.Version={{ .Version }}'
+      - '-X={{ .ModulePath }}/internal/version.Commit={{ .Commit }}'
+      - '-extldflags=-static'
+    goos:
+      - 'darwin'
+      - 'linux'
+      - 'windows'
+    goarch:
+      - 'amd64'
+      - 'arm64'
+
+archives:
+  - format: 'tar.gz'
+    name_template: 'pmap_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: 'windows'
+        format: 'zip'
+
+
+checksum:
+  name_template: 'pmap_{{ .Version }}_SHA512SUMS'
+  algorithm: 'sha512'
+
+
+changelog:
+  use: 'github'
+  sort: 'asc'
+
+# Release to github.
+release:
+  draft: false
+  mode: 'replace'


### PR DESCRIPTION
Add docker image release and github release to `release.yml` as a github workflow.

Both release are tested using my test project with some modified parameters like serviceAccount and registry repo. Here are  links to the release in the test project:
- [Artifact registry repo link](https://pantheon.corp.google.com/artifacts/docker/tycho-qinhang-jvs-dev-0a9a/us-central1/pmap-dev/pmap?e=-13802955&jsmode=o&mods=logs_tg_staging&project=tycho-qinhang-jvs-dev-0a9a).

- [Test github repo link](https://github.com/sailorlqh/github-action-test). 

You should be able to find the invite to the above github repo in another email.