### PR TITLE
Fix: Update tf vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           echo pmap_service_account=\"${{ env.INTEG_TEST_RUN_SERVICE_ACCOUNT }}\" >> ${VAR_FILE};
           echo oidc_service_account=\"${{ env.INTEG_TEST_OIDC_SERVICE_ACCOUNT }}\" >> ${VAR_FILE};
           echo gcs_events_filter=\"hasPrefix\(attributes.objectId, \\\"mapping/${INTEG_TEST_OBJECT_PREFIX}\\\"\)\">> ${VAR_FILE};
-          echo extra_container_env_vars={PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE=\"projects/${{ env.INTEG_TEST_PROJECT_ID}}\"} >> ${VAR_FILE}
+          echo service_specific_container_env_vars={PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE=\"projects/${{ env.INTEG_TEST_PROJECT_ID}}\"} >> ${VAR_FILE}
 
           cat ${VAR_FILE};
           echo "MAPPING_TF_VAR_FILE=${VAR_FILE}" >> $GITHUB_ENV;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           echo pmap_service_account=\"${{ env.INTEG_TEST_RUN_SERVICE_ACCOUNT }}\" >> ${VAR_FILE};
           echo oidc_service_account=\"${{ env.INTEG_TEST_OIDC_SERVICE_ACCOUNT }}\" >> ${VAR_FILE};
           echo gcs_events_filter=\"hasPrefix\(attributes.objectId, \\\"mapping/${INTEG_TEST_OBJECT_PREFIX}\\\"\)\">> ${VAR_FILE};
-          echo pmap_mapping_default_resource_scope=\"projects/${{ env.INTEG_TEST_PROJECT_ID }}\" >> ${VAR_FILE}
+          echo extra_container_env_vars={PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE=\"projects/${{ env.INTEG_TEST_PROJECT_ID}}\"} >> ${VAR_FILE}
 
           cat ${VAR_FILE};
           echo "MAPPING_TF_VAR_FILE=${VAR_FILE}" >> $GITHUB_ENV;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           echo pmap_service_account=\"${{ env.INTEG_TEST_RUN_SERVICE_ACCOUNT }}\" >> ${VAR_FILE};
           echo oidc_service_account=\"${{ env.INTEG_TEST_OIDC_SERVICE_ACCOUNT }}\" >> ${VAR_FILE};
           echo gcs_events_filter=\"hasPrefix\(attributes.objectId, \\\"mapping/${INTEG_TEST_OBJECT_PREFIX}\\\"\)\">> ${VAR_FILE};
-          echo service_specific_container_env_vars={PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE=\"projects/${{ env.INTEG_TEST_PROJECT_ID}}\"} >> ${VAR_FILE}
+          echo pmap_specific_envvars={PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE=\"projects/${{ env.INTEG_TEST_PROJECT_ID}}\"} >> ${VAR_FILE}
 
           cat ${VAR_FILE};
           echo "MAPPING_TF_VAR_FILE=${VAR_FILE}" >> $GITHUB_ENV;

--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -32,16 +32,16 @@ module "mapping_service" {
 
   project_id = var.project_id
 
-  service_name             = local.mapping_service_name
-  pmap_container_image     = var.pmap_container_image
-  pmap_args                = ["mapping", "server"]
-  upstream_topic           = module.common_infra.gcs_notification_topics[local.mapping_service_name].name
-  downstream_topic         = module.common_infra.bigquery_topics[local.mapping_service_name].event_topic
-  downstream_failure_topic = module.common_infra.bigquery_topics[local.mapping_service_name].failure_topic
-  pmap_service_account     = module.common_infra.run_service_account
-  oidc_service_account     = module.common_infra.oidc_service_account
-  gcs_events_filter        = var.mapping_gcs_events_filter
-  extra_container_env_vars = var.extra_container_env_vars
+  service_name                        = local.mapping_service_name
+  pmap_container_image                = var.pmap_container_image
+  pmap_args                           = ["mapping", "server"]
+  upstream_topic                      = module.common_infra.gcs_notification_topics[local.mapping_service_name].name
+  downstream_topic                    = module.common_infra.bigquery_topics[local.mapping_service_name].event_topic
+  downstream_failure_topic            = module.common_infra.bigquery_topics[local.mapping_service_name].failure_topic
+  pmap_service_account                = module.common_infra.run_service_account
+  oidc_service_account                = module.common_infra.oidc_service_account
+  gcs_events_filter                   = var.mapping_gcs_events_filter
+  service_specific_container_env_vars = var.service_specific_container_env_vars
 }
 
 module "policy_service" {

--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 locals {
-  mapping_service_name                = "mapping"
-  policy_service_name                 = "policy"
-  pmap_mapping_default_resource_scope = var.pmap_mapping_default_resource_scope == "" ? format("projects/%s", var.project_id) : var.pmap_mapping_default_resource_scope
+  mapping_service_name = "mapping"
+  policy_service_name  = "policy"
 }
 
 module "common_infra" {
@@ -33,16 +32,16 @@ module "mapping_service" {
 
   project_id = var.project_id
 
-  service_name                        = local.mapping_service_name
-  pmap_container_image                = var.pmap_container_image
-  pmap_args                           = ["mapping", "server"]
-  upstream_topic                      = module.common_infra.gcs_notification_topics[local.mapping_service_name].name
-  downstream_topic                    = module.common_infra.bigquery_topics[local.mapping_service_name].event_topic
-  downstream_failure_topic            = module.common_infra.bigquery_topics[local.mapping_service_name].failure_topic
-  pmap_service_account                = module.common_infra.run_service_account
-  oidc_service_account                = module.common_infra.oidc_service_account
-  gcs_events_filter                   = var.mapping_gcs_events_filter
-  pmap_mapping_default_resource_scope = local.pmap_mapping_default_resource_scope
+  service_name             = local.mapping_service_name
+  pmap_container_image     = var.pmap_container_image
+  pmap_args                = ["mapping", "server"]
+  upstream_topic           = module.common_infra.gcs_notification_topics[local.mapping_service_name].name
+  downstream_topic         = module.common_infra.bigquery_topics[local.mapping_service_name].event_topic
+  downstream_failure_topic = module.common_infra.bigquery_topics[local.mapping_service_name].failure_topic
+  pmap_service_account     = module.common_infra.run_service_account
+  oidc_service_account     = module.common_infra.oidc_service_account
+  gcs_events_filter        = var.mapping_gcs_events_filter
+  extra_container_env_vars = var.extra_container_env_vars
 }
 
 module "policy_service" {

--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -32,16 +32,16 @@ module "mapping_service" {
 
   project_id = var.project_id
 
-  service_name                        = local.mapping_service_name
-  pmap_container_image                = var.pmap_container_image
-  pmap_args                           = ["mapping", "server"]
-  upstream_topic                      = module.common_infra.gcs_notification_topics[local.mapping_service_name].name
-  downstream_topic                    = module.common_infra.bigquery_topics[local.mapping_service_name].event_topic
-  downstream_failure_topic            = module.common_infra.bigquery_topics[local.mapping_service_name].failure_topic
-  pmap_service_account                = module.common_infra.run_service_account
-  oidc_service_account                = module.common_infra.oidc_service_account
-  gcs_events_filter                   = var.mapping_gcs_events_filter
-  service_specific_container_env_vars = var.service_specific_container_env_vars
+  service_name             = local.mapping_service_name
+  pmap_container_image     = var.pmap_container_image
+  pmap_args                = ["mapping", "server"]
+  upstream_topic           = module.common_infra.gcs_notification_topics[local.mapping_service_name].name
+  downstream_topic         = module.common_infra.bigquery_topics[local.mapping_service_name].event_topic
+  downstream_failure_topic = module.common_infra.bigquery_topics[local.mapping_service_name].failure_topic
+  pmap_service_account     = module.common_infra.run_service_account
+  oidc_service_account     = module.common_infra.oidc_service_account
+  gcs_events_filter        = var.mapping_gcs_events_filter
+  pmap_specific_envvars    = var.pmap_specific_envvars
 }
 
 module "policy_service" {

--- a/terraform/e2e/variables.tf
+++ b/terraform/e2e/variables.tf
@@ -57,7 +57,7 @@ variable "bigquery_table_delete_protection" {
   default     = false
 }
 
-variable "extra_container_env_vars" {
+variable "service_specific_container_env_vars" {
   type        = map(string)
   description = <<EOT
         "The extra envirnoment variables for mapping services as key value pair.

--- a/terraform/e2e/variables.tf
+++ b/terraform/e2e/variables.tf
@@ -57,15 +57,19 @@ variable "bigquery_table_delete_protection" {
   default     = false
 }
 
-variable "pmap_mapping_default_resource_scope" {
+variable "extra_container_env_vars" {
+  type        = map(string)
   description = <<EOT
-        "The scope for where the resources resides in.
+        "The extra envirnoment variables for mapping services as key value pair.
+        Including <PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE>: 
+        The scope for where the resources resides in.
         Options can be one of the following:
         projects/{PROJECT_ID}
         projects/{PROJECT_NUMBER}
         folders/{FOLDER_NUMBER}
         organizations/{ORGANIZATION_NUMBER}"
+        Example:
+        {PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE: }
     EOT
-  type        = string
-  default     = ""
+  default     = {}
 }

--- a/terraform/e2e/variables.tf
+++ b/terraform/e2e/variables.tf
@@ -57,19 +57,15 @@ variable "bigquery_table_delete_protection" {
   default     = false
 }
 
-variable "service_specific_container_env_vars" {
+variable "pmap_specific_envvars" {
   type        = map(string)
   description = <<EOT
-        "The extra envirnoment variables for mapping services as key value pair.
-        Including <PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE>: 
-        The scope for where the resources resides in.
-        Options can be one of the following:
-        projects/{PROJECT_ID}
-        projects/{PROJECT_NUMBER}
-        folders/{FOLDER_NUMBER}
-        organizations/{ORGANIZATION_NUMBER}"
+        "The specific container envirnoment variables needed for pmap individual service.
+        This can be used by both mapping and policy service.
+        For example PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE is only required by
+        mapping service.
         Example:
-        {PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE: }
+        {PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE: projects/some-project-id}"
     EOT
   default     = {}
 }

--- a/terraform/modules/pmap-service/main.tf
+++ b/terraform/modules/pmap-service/main.tf
@@ -42,7 +42,7 @@ module "service" {
     invokers   = ["serviceAccount:${var.oidc_service_account}"]
   }
 
-  envvars = merge(local.common_env_vars, var.service_specific_container_env_vars)
+  envvars = merge(local.common_env_vars, var.pmap_specific_envvars)
 }
 
 // Create push subscriptions with the pmap service push endpoint.

--- a/terraform/modules/pmap-service/main.tf
+++ b/terraform/modules/pmap-service/main.tf
@@ -13,8 +13,13 @@
 // limitations under the License.
 
 locals {
-  pubsub_svc_account_email            = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-  pmap_mapping_default_resource_scope = var.pmap_mapping_default_resource_scope == "" ? format("projects/%s", var.project_id) : var.pmap_mapping_default_resource_scope
+  pubsub_svc_account_email = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+  basic_env_var = {
+    "PROJECT_ID" : var.project_id,
+    "PMAP_SUCCESS_TOPIC_ID" : var.downstream_topic,
+    "PMAP_FAILURE_TOPIC_ID" : var.downstream_failure_topic
+  }
 }
 
 data "google_project" "project" {
@@ -37,12 +42,7 @@ module "service" {
     invokers   = ["serviceAccount:${var.oidc_service_account}"]
   }
 
-  envvars = {
-    "PROJECT_ID" : var.project_id,
-    "PMAP_SUCCESS_TOPIC_ID" : var.downstream_topic,
-    "PMAP_FAILURE_TOPIC_ID" : var.downstream_failure_topic
-    "PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE" : local.pmap_mapping_default_resource_scope
-  }
+  envvars = merge(local.basic_env_var, var.extra_container_env_vars)
 }
 
 // Create push subscriptions with the pmap service push endpoint.

--- a/terraform/modules/pmap-service/main.tf
+++ b/terraform/modules/pmap-service/main.tf
@@ -15,7 +15,7 @@
 locals {
   pubsub_svc_account_email = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 
-  basic_env_var = {
+  common_env_vars = {
     "PROJECT_ID" : var.project_id,
     "PMAP_SUCCESS_TOPIC_ID" : var.downstream_topic,
     "PMAP_FAILURE_TOPIC_ID" : var.downstream_failure_topic
@@ -42,7 +42,7 @@ module "service" {
     invokers   = ["serviceAccount:${var.oidc_service_account}"]
   }
 
-  envvars = merge(local.basic_env_var, var.extra_container_env_vars)
+  envvars = merge(local.common_env_vars, var.service_specific_container_env_vars)
 }
 
 // Create push subscriptions with the pmap service push endpoint.

--- a/terraform/modules/pmap-service/variables.tf
+++ b/terraform/modules/pmap-service/variables.tf
@@ -74,10 +74,11 @@ variable "gcs_events_filter" {
   default     = null
 }
 
-variable "service_specific_container_env_vars" {
+variable "pmap_specific_envvars" {
   type        = map(string)
   description = <<EOT
-        "The container envirnoment variables needed for specific pmap service.
+        "The specific container envirnoment variables needed for pmap individual service.
+        This can be used by both mapping and policy service.
         For example PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE is only required by
         mapping service.
         Example:

--- a/terraform/modules/pmap-service/variables.tf
+++ b/terraform/modules/pmap-service/variables.tf
@@ -74,10 +74,10 @@ variable "gcs_events_filter" {
   default     = null
 }
 
-variable "extra_container_env_vars" {
+variable "service_specific_container_env_vars" {
   type        = map(string)
   description = <<EOT
-        "The extra container envirnoment variables needed specific pmap services.
+        "The container envirnoment variables needed for specific pmap service.
         For example PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE is only required by
         mapping service.
         Example:

--- a/terraform/modules/pmap-service/variables.tf
+++ b/terraform/modules/pmap-service/variables.tf
@@ -74,15 +74,14 @@ variable "gcs_events_filter" {
   default     = null
 }
 
-variable "pmap_mapping_default_resource_scope" {
+variable "extra_container_env_vars" {
+  type        = map(string)
   description = <<EOT
-        "The scope for where the resources resides in.
-        Options can be one of the following:
-        projects/{PROJECT_ID}
-        projects/{PROJECT_NUMBER}
-        folders/{FOLDER_NUMBER}
-        organizations/{ORGANIZATION_NUMBER}"
+        "The extra container envirnoment variables needed specific pmap services.
+        For example PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE is only required by
+        mapping service.
+        Example:
+        {PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE: projects/some-project-id}"
     EOT
-  type        = string
-  default     = ""
+  default     = {}
 }


### PR DESCRIPTION
I think it is a better way to have `defaultResourceScope` set only for mapping service.

By doing this, `PMAP_MAPPING_DEFAULT_RESOURCE_SCOPE` won't appear in policy service's env vars, and we don't need to default `var.pmap_mapping_default_resource_scope` and parse it to `project/project-id` for mapping service.

Also, using `extra_container_env_vars` (maybe a better naming can be discussed later), we can customize different env vars for different services. 

There are some other [cases](https://github.com/abcxyz/terraform-modules/blob/129d7928a4ed16d7b51ea5aca9df77018d8e7632/modules/cloud_run/main.tf#L112) for using `merge()` to setup env vars in `terraform-module` repo. So I think this might be a good approach.

I want to get some input from you before I convert this draft PR into ready for review.