### PR TITLE
feat: add terraform code for prober and its alerting policy

### DIFF
--- a/terraform/modules/monitoring/alert.tf
+++ b/terraform/modules/monitoring/alert.tf
@@ -1,0 +1,78 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+resource "google_project_service" "services" {
+  for_each = toset([
+    "monitoring.googleapis.com",
+  ])
+
+  project = var.project_id
+
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# The email channel where alert will be sent to.
+resource "google_monitoring_notification_channel" "email_notification_channel" {
+  project = var.project_id
+
+  display_name = "pmap alerts email channel"
+
+  type = "email"
+
+  labels = {
+    email_address = var.notification_channel_email
+  }
+
+  force_delete = false
+
+  depends_on = [
+    google_project_service.services["monitoring.googleapis.com"],
+  ]
+}
+
+# This alert will trigger if: in a user defined rolling window size, the number
+# of succeeded pmap-prober cloud job runs below the user defined threshold.
+resource "google_monitoring_alert_policy" "prober_service_success_number_below_threshold" {
+  project = var.project_id
+
+  display_name = "PMAP-Prober Service Alert: Number of successed PMAP probes below threshold"
+
+  combiner = "OR"
+
+  # Conditions are:
+  # 1. The metric is completed_execution_count
+  # 2. The metrics is applied to pmap-prober
+  # 3. Only count on success jobs.
+  # 4. When the number of succeeded jobs below
+  #    the threshold, alert will be triggered.
+  conditions {
+    display_name = "Too many failed PMAP probes"
+    condition_threshold {
+      filter          = "metric.type=\"run.googleapis.com/job/completed_execution_count\" resource.type=\"cloud_run_job\" resource.label.\"job_name\"=\"${google_cloud_run_v2_job.pmap_prober.name}\" AND metric.label.\"result\"=\"succeeded\""
+      duration        = "0s"
+      comparison      = "COMPARISON_LT"
+      threshold_value = var.prober_alert_threshold
+      aggregations {
+        alignment_period   = var.prober_alert_align_window_size_in_seconds
+        per_series_aligner = "ALIGN_COUNT"
+      }
+    }
+  }
+  notification_channels = [
+    google_monitoring_notification_channel.email_notification_channel.name
+  ]
+
+  enabled = var.alert_enabled
+}

--- a/terraform/modules/monitoring/prober.tf
+++ b/terraform/modules/monitoring/prober.tf
@@ -1,0 +1,133 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+locals {
+  prober_env_vars = {
+    "PROBER_PROJECT_ID" : var.project_id,
+    "PROBER_BUCKET_ID" : var.prober_bucket_id,
+    "PROBER_BIGQUERY_DATASET_ID" : var.prober_bigquery_dataset_id,
+    "PROBER_MAPPING_TABLE_ID" : var.prober_mapping_table_id,
+    "PROBER_POLICY_TABLE_ID" : var.prober_policy_table_id,
+    "PROBER_MAPPING_GCS_BUCKET_PREFIX" : var.prober_mapping_gcs_bucket_prefix,
+    "PROBER_POLICY_GCS_BUCKET_PREFIX" : var.prober_policy_gcs_bucket_prefix,
+    "PROBER_QUERY_RETRY_WAIT_DURATION" : var.prober_query_retry_wait_duartion,
+    "PROBER_QUERY_RETRY_COUNT" : var.prober_query_retry_count,
+    "LOG_LEVEL" : var.log_level
+  }
+}
+resource "google_cloud_run_v2_job" "pmap_prober" {
+
+  project = var.project_id
+
+  name = "pmap-prober"
+
+  location = "us-central1"
+
+  template {
+
+    template {
+
+      max_retries = 3
+
+      containers {
+        image = var.pmap_prober_image
+
+        dynamic "env" {
+          for_each = local.prober_env_vars
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+      service_account = google_service_account.prober_service_account.email
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}
+
+# This is prober dedicated service accout.
+# This service account will be used to trigger cloud run job by cloud scheduler
+# and also used by prober for upload GCS object and query bigquery table.
+resource "google_service_account" "prober_service_account" {
+  project = var.project_id
+
+  account_id   = "pmap-prober"
+  display_name = "Prober Service Account"
+}
+
+# Grant pmap-prober cloud run invoker and bigquery job user role.
+resource "google_project_iam_member" "prober_sa_role" {
+  for_each = toset([
+    "roles/bigquery.jobUser",
+    "roles/run.invoker",
+  ])
+
+  project = var.project_id
+
+  role   = each.value
+  member = google_service_account.prober_service_account.member
+}
+
+# Grant pmap-prober GCS objectCreator role
+resource "google_storage_bucket_iam_member" "member" {
+  bucket = var.prober_bucket_id
+  role   = "roles/storage.objectCreator"
+  member = google_service_account.prober_service_account.member
+}
+
+# Grant pmap-prober bigqeury dataviewer role
+resource "google_bigquery_dataset_iam_member" "viewer" {
+  for_each = toset([
+    "roles/bigquery.dataViewer",
+  ])
+
+  project = var.project_id
+
+  dataset_id = var.prober_bigquery_dataset_id
+  role       = each.value
+  member     = google_service_account.prober_service_account.member
+}
+
+# This is the scheduler for triggering pmap-prober cloud run job
+# in a user defined frequency.
+resource "google_cloud_scheduler_job" "job" {
+
+  project = var.project_id
+
+  schedule    = var.prober_scheduler
+  name        = "pmap-prober-scheduler"
+  description = "prober cloud run job scheduler"
+  region      = "us-central1"
+
+  retry_config {
+    retry_count = 0
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${resource.google_cloud_run_v2_job.pmap_prober.location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${resource.google_cloud_run_v2_job.pmap_prober.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.prober_service_account.email
+    }
+  }
+
+  depends_on = [google_cloud_run_v2_job.pmap_prober]
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,102 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+variable "project_id" {
+  description = "The GCP project that host the pmap service."
+  type        = string
+}
+
+variable "prober_bucket_id" {
+  description = "The bucket id where prober will upload files to."
+  type        = string
+}
+
+variable "prober_bigquery_dataset_id" {
+  description = "The ID of the bigquery dataset where prober run queries from."
+  type        = string
+}
+
+variable "prober_mapping_table_id" {
+  description = "The ID of the bigquery table which stores the resource mapping result."
+  type        = string
+}
+
+variable "prober_policy_table_id" {
+  description = "The ID of the bigquery table which stores the policy result."
+  type        = string
+}
+
+variable "prober_query_retry_wait_duartion" {
+  description = "The wait duation between the next bigquery query retry attempt."
+  type        = string
+  default     = "5s"
+}
+
+variable "prober_query_retry_count" {
+  description = "The max number for bigquery query retry attempt."
+  type        = string
+  default     = "5"
+}
+
+variable "prober_mapping_gcs_bucket_prefix" {
+  description = "The file name prefix for mapping."
+  type        = string
+  default     = "mapping/prober"
+}
+
+variable "prober_policy_gcs_bucket_prefix" {
+  description = "The file name prefix for policy."
+  type        = string
+  default     = "policy/prober"
+}
+
+variable "prober_scheduler" {
+  type        = string
+  description = "How often the prober service should be triggered, default is every 30 minutes. Learn more at: https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules?&_ga=2.26495481.-578386315.1680561063#defining_the_job_schedule."
+  default     = "*/30 * * * *"
+}
+
+variable "pmap_prober_image" {
+  type        = string
+  description = "Docker image for pmap prober."
+}
+
+variable "prober_alert_threshold" {
+  type        = number
+  description = "Send alert for Prober-Service when the number of succeeded prober runs below the threshold."
+  default     = 2
+}
+
+variable "prober_alert_align_window_size_in_seconds" {
+  type        = string
+  description = "The sliding window size for counting failed prober job runs. Format example: 600s."
+  default     = "3600s"
+}
+
+variable "alert_enabled" {
+  type        = bool
+  description = "True if alerts are enabled, otherwise false."
+  default     = false
+}
+
+variable "notification_channel_email" {
+  type        = string
+  description = "The Email address where alert notifications send to."
+}
+
+variable "log_level" {
+  type        = string
+  description = "Log level for writting logs"
+  default     = "DEBUG"
+}


### PR DESCRIPTION
This pr is part of the fix for #157.

There will be a separate PR for adding monitoring module into e2e.

Successfully tested with my own project.