### PR TITLE
Feat: add prober to pmap e2e module, also export prober service account

### DIFF
--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -58,3 +58,16 @@ module "policy_service" {
   oidc_service_account = module.common_infra.oidc_service_account
   gcs_events_filter    = var.policy_gcs_events_filter
 }
+
+module "prober_job" {
+  source = "../modules/monitoring"
+
+  project_id = var.project_id
+
+  prober_bucket_id           = var.gcs_bucket_name
+  prober_bigquery_dataset_id = module.common_infra.bigquery_dataset
+  prober_mapping_table_id    = local.mapping_service_name
+  prober_policy_table_id     = local.policy_service_name
+  pmap_prober_image          = var.pmap_prober_image
+  notification_channel_email = var.notification_channel_email
+}

--- a/terraform/e2e/variables.tf
+++ b/terraform/e2e/variables.tf
@@ -69,3 +69,13 @@ variable "pmap_specific_envvars" {
     EOT
   default     = {}
 }
+
+variable "pmap_prober_image" {
+  type        = string
+  description = "Docker image for pmap prober."
+}
+
+variable "notification_channel_email" {
+  type        = string
+  description = "The Email address where alert notifications send to."
+}

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,9 @@
+output "prober_service_account" {
+  description = "Service Account for prober"
+  value       = google_service_account.prober_service_account.email
+}
+
+output "prober_service_account_name" {
+  description = "Name of the Service Account for prober"
+  value       = google_service_account.prober_service_account.name
+}


### PR DESCRIPTION
As part of the fix for #157 