### PR TITLE
feat: update prober image in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,19 +120,19 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-    - name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
-      with:
-        workload_identity_provider: '${{ env.WIF_PROVIDER }}'
-        service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
-    - name: 'Update prober job'
-      run: |-
-        # Image tags are without 'v' prefix.
-        DOCKER_TAG="${{ github.ref_name }}"
-        DOCKER_TAG="${DOCKER_TAG#v}"
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Update prober job'
+        run: |-
+          # Image tags are without 'v' prefix.
+          DOCKER_TAG="${{ github.ref_name }}"
+          DOCKER_TAG="${DOCKER_TAG#v}"
 
-        # Update Prober job.
-        gcloud run jobs update pmap-prober \
-          --project="${{ env.DEV_PROJECT_ID }}" \
-          --region="${{ env.DEV_REGION }}" \
-          --image="${{ env.DOCKER_REPO }}/pmap-prober:${DOCKER_TAG}-amd64"
+          # Update Prober job.
+          gcloud run jobs update pmap-prober \
+            --project="${{ env.DEV_PROJECT_ID }}" \
+            --region="${{ env.DEV_REGION }}" \
+            --image="${{ env.DOCKER_REPO }}/pmap-prober:${DOCKER_TAG}-amd64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,27 @@ jobs:
             --project="${{ env.DEV_PROJECT_ID }}" \
             --region="${{ env.DEV_REGION }}" \
             --image="${{ env.DOCKER_REPO }}/pmap:${DOCKER_TAG}-amd64"
+
+  deploy-dev-prober:
+    needs: ['github-release']
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
+      with:
+        workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+        service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+    - name: 'Update prober job'
+      run: |-
+        # Image tags are without 'v' prefix.
+        DOCKER_TAG="${{ github.ref_name }}"
+        DOCKER_TAG="${DOCKER_TAG#v}"
+
+        # Update Prober job.
+        gcloud run jobs update pmap-prober \
+          --project="${{ env.DEV_PROJECT_ID }}" \
+          --region="${{ env.DEV_REGION }}" \
+          --image="${{ env.DOCKER_REPO }}/pmap-prober:${DOCKER_TAG}-amd64"

--- a/terraform/modules/monitoring/prober.tf
+++ b/terraform/modules/monitoring/prober.tf
@@ -58,6 +58,7 @@ resource "google_cloud_run_v2_job" "pmap_prober" {
   lifecycle {
     ignore_changes = [
       launch_stage,
+      template[0].template[0].containers[0].image,
     ]
   }
 }


### PR DESCRIPTION
Sorry that I pushed `tag v0.0.4` before updating this release file. So I updated the infra repo to use the lastest image to create and deploy prober cloud run job. And in this PR, I add the `gcloud` cmd to update the prober image so future release can update prober's image directly.