### PR TITLE
chore: create-tag workflow for release

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,48 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create an annotated tag in the repo default branch.
+name: 'create_tag'
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The name of the tag to be created.'
+        type: 'string'
+        required: true
+      message:
+        description: 'Message for the tag. Default will be the tag name.'
+        type: 'string'
+        required: false
+
+jobs:
+  create_tag:
+    permissions:
+      # Job need OIDC for token minter to work, see ref:
+      # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+      id-token: 'write'
+    uses: 'abcxyz/pkg/.github/workflows/create-tag.yml@main' # ratchet:exclude
+    with:
+      tag: '${{ inputs.tag }}'
+      branch: '${{ github.event.repository.default_branch }}'
+      # Set message default here since workflow_dispatch inputs do not have the
+      # access to the context.
+      message: '${{ inputs.message || inputs.tag }}'
+      annotated_tag: true
+      deployment_environment: 'tag'
+      token_minter_wif_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+      token_minter_wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+      token_minter_service_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+      token_minter_service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,37 +11,30 @@ split the two releases into two config files:
 
 ## New Release
 
--   Send a PR to update all dependencies For Go, 
-```sh 
-go get -u ./... && go mod tidy
-```
--   Sync to main/HEAD 
-```sh 
-# Checkout to the main/HEAD 
-git checkout main
-```
--   Create a tag using semantic versioning and then push the tag.
-    -   If there are breaking changes, bump the major version
-    -   If there are new major features (but not breaking), bump the minor
-        version
-    -   Nothing important, bump the patch version.
-    -   Feel free to use suffixes -alpha, -beta and -rc as needed 
-
+-   Send a PR to update all dependencies For Go
 ```sh
-REL_VER=v0.0.x
-# Tag
-git tag -f -a $REL_VER -m $REL_VER
-# Push tag. This will trigger the release workflow.
-git push origin $REL_VER 
-``` 
-The new pushed tag should trigger the release
-workflow which typically does two things: 
-- Create a GitHub release with
-artifacts (e.g. code zip, binaries, etc.). Note: Goreleaser will automatically
-use the git change log to fill the release note. 
-- Test, build and upload
-artifacts to Artifact Registry (e.g. container images etc.).
-- Deploy to PMAP demo GCP project.
+go get -u && go mod tidy
+```
+-   Create a tag using `.github/workflows/create-tag.yml` on default branch and
+    run the workflow with below inputs.
+
+    -   tag name with format `v0.x.x`, using semantic versioning.
+        -   If there are breaking changes, bump the major version.
+        -   If there are new major features (but not breaking), bump the minor
+            version.
+        -   Nothing important, bump the patch version.
+        -   Feel free to use suffixes -alpha, -beta and -rc as needed.
+    -   skip to use default message (tag name).
+
+-   The new tag created should trigger the release workflow which typically does
+    three things:
+
+    -   Integration test.
+    -   Container image release and push the images to container registry
+        `us-docker.pkg.dev/abcxyz-artifacts/docker-images`.
+    -   GitHub release with artifacts (e.g. code zip, binaries, etc.).
+        Note: Goreleaser will automatically use the git change log to fill the
+        release note.
 
 ## Manually Release Images
 


### PR DESCRIPTION
Pending - create the repo environment `tag` to enforce required review.